### PR TITLE
chore: setup eslint, prettier and commitlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.js]
+quote_type = single
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+	"extends": ["@ljharb", "@ljharb/eslint-config/node/latest"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Only apps should have lockfiles
+npm-shrinkwrap.json
+package-lock.json
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+'use strict';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "can-merge",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"bin": {
+		"can-merge": "./index.js"
+	},
+	"scripts": {
+		"lint": "eslint --ext=js,mjs ."
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ljharb/can-merge.git"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/ljharb/can-merge/issues"
+	},
+	"homepage": "https://github.com/ljharb/can-merge#readme",
+	"devDependencies": {
+		"@ljharb/eslint-config": "^17.6.0",
+		"eslint": "^7.29.0"
+	}
+}


### PR DESCRIPTION
## Description

This PR sets up:
 
- `eslint` for linting code and enforcing code conventions
- `prettier` to ensure our code confirms to a particular style guide
- `commitlint` and `commitizen` to enforce the commit messages to confirm to conventional commit rules. 