### PR TITLE
[Feature] check status of commits

### DIFF
--- a/bin/can-merge
+++ b/bin/can-merge
@@ -18,6 +18,8 @@ const parsePullRequest = require('../utils/parsePullRequest');
 const parseRemoteUrl = require('../utils/parseRemoteUrl');
 const pullRequestStatus = require('../utils/models/pullRequestStatus');
 const getMessage = require('../utils/getMessage');
+const evaluateCommitStatus = require('../utils/evaluateCommitStatus');
+const commitStatus = require('../utils/models/commitStatus');
 
 const {
 	GITHUB_TOKEN,
@@ -35,6 +37,13 @@ const args = Yargs
 	.help()
 	.strict()
 	.options({
+		commit: {
+			alias: 'c',
+			default: false,
+			demandOption: false,
+			describe: 'check commit status',
+			type: 'boolean',
+		},
 		pr: {
 			alias: 'p',
 			demandOption: false,
@@ -72,7 +81,6 @@ const args = Yargs
 		},
 		watch: {
 			alias: 'w',
-			default: false,
 			describe: 'watch pending checks',
 			type: 'boolean',
 		},
@@ -110,22 +118,33 @@ const args = Yargs
 
 const token = args.token || GITHUB_TOKEN || GH_TOKEN;
 
+// eslint-disable-next-line max-lines-per-function
 function outputStatus(response) {
 	if (NODE_ENV === 'DEBUG') {
 		console.log(JSON.stringify(response, null, 2));
 	}
+	if (args.commit) {
+		if (response.repository.commit === null) {
+			console.info(chalk.redBright(`⚠ This remote repository does not contain any commits matching sha: ${args.sha}`));
+		} else {
+			const status = evaluateCommitStatus(response.repository.commit);
+			console.info(getMessage(status));
+			if (status !== commitStatus.STATUS_SUCCESS) {
+				process.exitCode = (process.exitCode ?? 0) + 1;
+			}
+		}
+	}
 	const prs = parsePullRequest(response);
-	if (prs.length === 0) {
+	if (prs.length === 0 && !args.commit) {
 		if (args.pr) {
 			console.info(chalk.redBright(`⚠ This remote repository does not contain any pull requests matching number: ${args.pr}`));
 		} else {
 			console.info(chalk.redBright(`⚠ This remote repository does not contain any pull requests matching sha: ${args.sha}`));
 		}
-		process.exitCode = 1;
 	} else {
 		prs.forEach((pr) => {
 			const status = evaluatePullRequest(pr);
-			console.info('PR:', pr.number, getMessage(status));
+			console.info('PR status:', pr.number, getMessage(status));
 			if (status !== pullRequestStatus.MERGEABLE) {
 				process.exitCode = (process.exitCode ?? 0) + 1;
 			}
@@ -152,6 +171,7 @@ const options = {
 
 https.request(options, (response) => {
 	const params = {
+		commit: args.commit,
 		repo: parseRemoteUrl(response.headers?.location) ?? String(repo),
 		pr,
 		sha: pr ? null : sha,

--- a/utils/evaluateCommitStatus.js
+++ b/utils/evaluateCommitStatus.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const commitStatus = require('./models/commitStatus');
+
+const success = (commit) => commit?.statusCheckRollup?.state === 'SUCCESS';
+const failure = (commit) => commit?.statusCheckRollup?.state === 'ERROR' || commit?.statusCheckRollup?.state === 'FAILURE';
+const pending = (commit) => commit?.statusCheckRollup?.state === 'PENDING';
+
+module.exports = function evaluateCommitStatus(commit) {
+	if (success(commit)) {
+		return commitStatus.STATUS_SUCCESS;
+	}
+	if (failure(commit)) {
+		return commitStatus.STATUS_FAILURE;
+	}
+	if (pending(commit)) {
+		return commitStatus.STATUS_PENDING;
+	}
+	return commitStatus.STATUS_NOT_FOUND;
+};

--- a/utils/evaluatePending.js
+++ b/utils/evaluatePending.js
@@ -1,10 +1,8 @@
 'use strict';
 
 module.exports = function evaluatePending(response) {
-	const { search: { edges: [{ node: { commits: { nodes: [{ commit: { statusCheckRollup } }] } } }] } } = response;
+	const pullRequestPending = response.search?.edges[0].node.commits.nodes[0].commit.statusCheckRollup.state === 'PENDING';
+	const commitRequestPending = response.repository?.commit.statusCheckRollup.state === 'PENDING';
 
-	// eslint-disable-next-line no-underscore-dangle
-	const pending = statusCheckRollup.contexts.nodes.filter((ctx) => (ctx.__typename === 'CheckRun' && ctx.status !== 'COMPLETED') || (ctx.__typename === 'StatusContext' && ctx.state === 'PENDING'));
-
-	return pending.length;
+	return pullRequestPending || commitRequestPending;
 };

--- a/utils/getMessage.js
+++ b/utils/getMessage.js
@@ -2,6 +2,7 @@
 
 const chalk = require('chalk');
 const pullRequestStatus = require('./models/pullRequestStatus');
+const commitStatus = require('./models/commitStatus');
 
 const messages = {
 	[pullRequestStatus.CLOSED]: chalk.redBright(pullRequestStatus.CLOSED),
@@ -12,7 +13,11 @@ const messages = {
 	[pullRequestStatus.REVIEW_DISAPPROVED]: chalk.yellowBright(pullRequestStatus.REVIEW_DISAPPROVED),
 	[pullRequestStatus.REVIEW_REQUIRED]: chalk.redBright(pullRequestStatus.REVIEW_REQUIRED),
 	[pullRequestStatus.STATUS_FAILURE]: chalk.blueBright(pullRequestStatus.STATUS_FAILURE),
-	[pullRequestStatus.STATUS_PENDING]: chalk.yellowBright(pullRequestStatus.STATUS_PENDING),
+	[pullRequestStatus.STATUSCHECK_PENDING]: chalk.yellowBright(pullRequestStatus.STATUSCHECK_PENDING),
+	[commitStatus.STATUS_FAILURE]: chalk.redBright(commitStatus.STATUS_FAILURE),
+	[commitStatus.STATUS_PENDING]: chalk.yellowBright(commitStatus.STATUS_PENDING),
+	[commitStatus.STATUS_SUCCESS]: chalk.greenBright(commitStatus.STATUS_SUCCESS),
+	[commitStatus.STATUS_NOT_FOUND]: chalk.yellowBright(commitStatus.STATUS_NOT_FOUND),
 };
 
 module.exports = function getMessage(response) {

--- a/utils/models/commitStatus.js
+++ b/utils/models/commitStatus.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+	STATUS_FAILURE: '⚠ Some commit checks were not successful',
+	STATUS_NOT_FOUND: 'ℹ No commit checks were found',
+	STATUS_PENDING: '⌛ Some commit checks are pending',
+	STATUS_SUCCESS: '✔ All commit checks are successful',
+};

--- a/utils/runQuery.js
+++ b/utils/runQuery.js
@@ -3,11 +3,11 @@
 const { graphql } = require('@octokit/graphql');
 const buildQuery = require('./buildQuery');
 
-module.exports = async function runQuery({ repo, pr, sha, token }) {
+module.exports = async function runQuery({ commit, repo, pr, sha, token }) {
 	const [owner, name] = repo.split('/');
 	let response = null;
 	try {
-		response = await graphql(buildQuery({ name, owner, pr, sha }), {
+		response = await graphql(buildQuery({ commit, name, owner, pr, sha }), {
 			headers: {
 				authorization: `token ${token}`,
 			},

--- a/utils/watch.js
+++ b/utils/watch.js
@@ -5,9 +5,9 @@ const evaluatePending = require('../utils/evaluatePending');
 module.exports = async function watch(retryDelay, getResponse) {
 	const response = await getResponse();
 
-	const pendingChecks = evaluatePending(response);
+	const isPendingChecks = evaluatePending(response);
 
-	if (pendingChecks === 0) {
+	if (!isPendingChecks) {
 		return response;
 	}
 


### PR DESCRIPTION
Closes #20

When  `--commit`  flag is specified, status of commits are checked for `success`, `failure` or `pending`.

<img width="880" alt="Screenshot 2021-11-17 at 11 05 48 PM" src="https://user-images.githubusercontent.com/61330148/142253907-ee8cf7aa-c481-49d4-8b1f-ffb59360bb54.png">

Need some discussion around the point mentioned in the [issue](https://github.com/ljharb/can-merge/issues/20)

1. Why should failure of a commit status make a PR not mergeable? 
- Currently adding a `--commit` flag would show the status of commits but the PR mergeable logic stays the same.
(`--commit` can be considered as a flag to see the status of commits as well maybe? But not change the logic of mergeable PRs)
