### PR TITLE
[Test] Add tests for `getSHA`

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,28 +5,39 @@ const test = require('tape');
 const evaluatePullRequest = require('../utils/evaluatePullRequest');
 const parsePullRequest = require('../utils/parsePullRequest');
 const getRepo = require('../utils/getRepo');
+const getSHA = require('../utils/getSHA');
 
 const { mockEvalPR, mockParsePR } = require('./mocks');
 
 test('evaluatePullRequest', (t) => {
-	t.plan(mockEvalPR.length);
 	mockEvalPR.forEach((mock) => {
 		t.equal(evaluatePullRequest(mock.res.repository.pullRequest), mock.expected, mock.description);
 	});
+
 	t.end();
 });
 
 test('parsePullRequest', (t) => {
-	t.plan(mockParsePR.length);
 	mockParsePR.forEach((mock) => {
 		t.deepEqual(parsePullRequest(mock.repository), mock.expected, mock.description);
 	});
+
 	t.end();
 });
 
 test('getRepo', (t) => {
-	t.plan(2);
 	t.match(getRepo(), /[^/]+\/can-merge/);
 	t.looseEqual(getRepo('invalidvalue'), null);
+
+	t.end();
+});
+
+test('getSHA', (t) => {
+	const long = getSHA();
+	const short = getSHA(true);
+	t.match(long, /^[a-zA-Z0-9]{40}$/);
+	t.match(short, /^[a-zA-Z0-9]{10}$/);
+	t.ok(long.startsWith(short), 'short SHA is a prefix of long SHA');
+
 	t.end();
 });


### PR DESCRIPTION
Adds tests for `getSHA`. Checks SHA by only looking at length of digits returned. SHA is 40 digits by default and short from `git-repo-info` is 10.


Contributes to #16 