### PR TITLE
[Docs] creates CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## For Contributors:
+
+In your local clone, create a ```.env``` file and add:
+
+```bash
+GITHUB_TOKEN = <github access token>
+```
+Run the following commands:
+```bash
+npm install
+```
+Add CLI arguments as needed (see [Usage](#usage))
+```bash
+node . 
+```


### PR DESCRIPTION
Currently, the `README.md` doesn't mention set-up guidelines for contributors (Noticed this after several of us MLH Fellows had similar doubts)
This edit adds a local installation instruction section to solve the same