### PR TITLE
Fix : Commit statuses from forks are not included 

### DIFF
--- a/utils/buildQuery.js
+++ b/utils/buildQuery.js
@@ -26,6 +26,12 @@ const pullRequestQuery = (name, owner, pr, sha) => `
 					commits(last: 1) {
 						nodes {
 							commit {
+								oid
+								author {
+									user {
+										url
+									}
+								}
 								statusCheckRollup {
 									state
 									contexts(last: 100) {
@@ -70,6 +76,13 @@ const commitStatusQuery = (name, owner, sha) => `
 			... on Commit {
 				statusCheckRollup {
 					state
+					commit {
+						author {
+							user {
+								url
+							}
+						}
+					}
 					contexts(last: 100) {
 						totalCount
 						pageInfo {

--- a/utils/models/pullRequestStatus.js
+++ b/utils/models/pullRequestStatus.js
@@ -8,7 +8,7 @@ module.exports = {
 	REVIEW_APPROVED: '✔ This PR has been approved',
 	REVIEW_DISAPPROVED: 'ℹ There are requested changes on this PR - merging is blocked',
 	REVIEW_REQUIRED: 'ℹ This PR requires a review - merging is blocked',
-	STATUS_FAILURE: '⚠ Some status checks are not successful',
+	STATUS_FAILURE: '⚠ Some status checks were not successful',
 	STATUS_PENDING: 'ℹ Some status checks are pending',
 	BYPASSABLE: 'ℹ This PR requires a review before merging, but as an ADMIN with merge rights you can bypass that restriction',
 };

--- a/utils/runQuery.js
+++ b/utils/runQuery.js
@@ -3,6 +3,52 @@
 const { graphql } = require('@octokit/graphql');
 const buildQuery = require('./buildQuery');
 
+const getCommitChecks = async (name, owner, sha, token) => {
+	const q = `
+		repository(name: "${name}", owner: "${owner}") {
+			commit: object(expression: "${sha}") {
+				... on Commit {
+					statusCheckRollup {
+						state
+						contexts(last: 100) {
+							totalCount
+							pageInfo {
+								endCursor
+								hasNextPage
+							}
+						nodes {
+							__typename
+							... on CheckRun {
+								status
+								name
+								conclusion
+							}
+							... on StatusContext {
+								state
+								context
+								description
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+	try {
+		const response = await graphql(`{${q}}`, {
+			headers: {
+				authorization: `token ${token}`,
+			},
+		});
+		return response.repository.commit?.statusCheckRollup?.contexts?.nodes;
+	} catch (error) {
+		console.log(error);
+		return null;
+	}
+};
+
 module.exports = async function runQuery({ commit, repo, pr, sha, token }) {
 	const [owner, name] = repo.split('/');
 	let response = null;
@@ -11,6 +57,43 @@ module.exports = async function runQuery({ commit, repo, pr, sha, token }) {
 			headers: {
 				authorization: `token ${token}`,
 			},
+		});
+		const { search, repository } = response;
+
+		const doNodes = async ({ commit }) =>{
+			const {
+				author: {
+					user: { url },
+				},
+				oid,
+			} = commit;
+			// get the commit checks for the commit that ran on the fork
+			await getCommitChecks(
+				name,
+				url.split('/').slice(-1).shift(),
+				oid,
+				token
+			).then((commitChecks) => {
+				const prchecks = commit.statusCheckRollup?.contexts.nodes ?? [];
+				const allChecks = prchecks.concat(commitChecks || []);
+				// modify the values only if checks are found
+				if (allChecks.length > 0) {
+					commit.statusCheckRollup.contexts.nodes = allChecks;
+					commit.statusCheckRollup.contexts.totalCount = allChecks.length;
+				}
+
+			});
+		};
+
+		await search.edges.reduce(async (prev, edge) => {
+			await prev;
+			return edge.node.commits.nodes.reduce(
+				async (prev, node) => {
+					await prev;
+					return doNodes(node);
+				},
+				Promise.resolve()
+			);
 		});
 	} catch (err) {
 		throw err.message;


### PR DESCRIPTION
can-merge was not fetching the commit statuses from forks, this PR addresses the issue.
 There's no way in the github API that allows us to get those checks, only way to get the commit checks of a commit is by providing the original owner of the commit and then running the repository/search query.

As discussed with @ljharb  I started by modifying the `buildQUery` so that it return us the original author of the commit along with the commits.
In the `runQuery.js` i've added a new query that basically is similar to the repo query that we already use, and it calls the github api with the actual author of the commit, which returns us the commit checks. I then merge the two checks.

I've added this modification to just the search query for now, and can update it to work for the repo query as well after the reviews.🙂
