### PR TITLE
Bypassable restrictions #Issue-23

### DIFF
--- a/test/mocks/evalPR.js
+++ b/test/mocks/evalPR.js
@@ -718,5 +718,67 @@ module.exports = [
 		},
 		"expected": pullRequestStatus.MERGEABLE,
 		"description": "evaluation of a PR with SUCCESS should return MERGEABLE"
+	},
+	{
+		"pullRequest": {
+			"state": "OPEN",
+			"url": "https://github.com/Common1818/branchProtection/pull/1",
+			"title": "Sample pr",
+			"author": {
+				"login": "Kartik18g"
+			},
+			"viewerCanMergeAsAdmin": true,
+			"number": 1,
+			"merged": false,
+			"mergeable": "MERGEABLE",
+			"reviewDecision": "REVIEW_REQUIRED",
+			"potentialMergeCommit": {
+				"commitUrl":
+					"https://github.com/Common1818/branchProtection/commit/b829099bdc69e4b84f04be23a8c67ebdcfbc9d26"
+			},
+			"commits": {
+				"nodes": [
+					{
+						"commit": {
+							"statusCheckRollup": null
+						}
+					}
+				]
+			}
+		},
+		"expected": pullRequestStatus.BYPASSABLE,
+		"description":
+			"evaluation of a PR which requires review but as an admin with merge rights should return BYPASSABLE"
+	},
+	{
+		"pullRequest": {
+			"state": "OPEN",
+			"url": "https://github.com/Common1818/branchProtection/pull/1",
+			"title": "Sample pr",
+			"author": {
+				"login": "Kartik18g"
+			},
+			"viewerCanMergeAsAdmin": false,
+			"number": 1,
+			"merged": false,
+			"mergeable": "MERGEABLE",
+			"reviewDecision": "REVIEW_REQUIRED",
+			"potentialMergeCommit": {
+				"commitUrl":
+					"https://github.com/Common1818/branchProtection/commit/b829099bdc69e4b84f04be23a8c67ebdcfbc9d26"
+			},
+			"commits": {
+				"nodes": [
+					{
+						"commit": {
+							"statusCheckRollup": null
+						}
+					}
+				]
+			}
+		},
+		"expected": pullRequestStatus.REVIEW_REQUIRED,
+		"description":
+			"evaluation of a PR which requires review but if not an admin with merge rights you return REVIEW_REQUIRED"
 	}
 ];

--- a/test/mocks/filterPR.json
+++ b/test/mocks/filterPR.json
@@ -1,461 +1,394 @@
-[
-	{
-		"response": {
-			"search": {
-				"edges": []
-			}
-		},
+[{
+        "response": {
+            "search": {
+                "edges": []
+            }
+        },
         "argPr": "1",
-		"expected": [],
-		"description": "No pr found: No pr found in repository should return an empty array regardless of argPR"
-	},
-	{
-		"response": {
-			"search": {
-				"edges": [
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-								"title": "dummy PR",
-								"number": 1,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					}
-				]
-			}
-		},
-        "argPr" : "1",
-		"expected": [
-			{
-				"state": "OPEN",
-				"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-				"title": "dummy PR",
-				"number": 1,
-				"merged": false,
-				"mergeable": "MERGEABLE",
-				"reviewDecision": null,
-				"potentialMergeCommit": {
-					"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-				},
-				"commits": {
-					"nodes": [
-						{
-							"commit": {
-								"statusCheckRollup": null
-							}
-						}
-					]
-				}
-			}
-		],
-		"description": "One pr found and argPR specified found: return parsed response in an array length === 1"
-	},
+        "expected": [],
+        "description": "No pr found: No pr found in repository should return an empty array regardless of argPR"
+    },
     {
-		"response": {
-			"search": {
-				"edges": [
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-								"title": "dummy PR",
-								"number": 1,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					}
-				]
-			}
-		},
-        "argPr" : "2",
-		"expected": [],
-		"description": "One pr found and argPR specified but not found: return empty array"
-	},
-	{
-		"response": {
-			"search": {
-				"edges": [
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-								"title": "dummy PR",
-								"number": 1,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
-								"title": "dummy PR 2",
-								"number": 2,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
-								"title": "dummy PR 3",
-								"number": 3,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					}
-				]
-			},
-			"rateLimit": {
-				"cost": 2,
-				"remaining": 4997
-			}
-		},
+        "response": {
+            "search": {
+                "edges": [{
+                    "node": [{
+                        "state": "OPEN",
+                        "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+                        "title": "dummy PR",
+                        "number": 1,
+                        "merged": false,
+                        "mergeable": "MERGEABLE",
+                        "reviewDecision": null,
+                        "potentialMergeCommit": {
+                            "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+                        },
+                        "commits": {
+                            "nodes": [{
+                                "commit": {
+                                    "statusCheckRollup": null
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }
+        },
         "argPr": "1",
-		"expected": [
-			{
-				"state": "OPEN",
-				"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-				"title": "dummy PR",
-				"number": 1,
-				"merged": false,
-				"mergeable": "MERGEABLE",
-				"reviewDecision": null,
-				"potentialMergeCommit": {
-					"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-				},
-				"commits": {
-					"nodes": [
-						{
-							"commit": {
-								"statusCheckRollup": null
-							}
-						}
-					]
-				}
-			}
-		],
-		"description": "Multiple prs found and argPR specified found: filter out and only return one that matches argPr"
-	},
+        "expected": [{
+            "state": "OPEN",
+            "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+            "title": "dummy PR",
+            "number": 1,
+            "merged": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": null,
+            "potentialMergeCommit": {
+                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+            },
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": null
+                    }
+                }]
+            }
+        }],
+        "description": "One pr found and argPR specified found: return parsed response in an array length === 1"
+    },
     {
-		"response": {
-			"search": {
-				"edges": [
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-								"title": "dummy PR",
-								"number": 5,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
-								"title": "dummy PR 2",
-								"number": 2,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
-								"title": "dummy PR 3",
-								"number": 3,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					}
-				]
-			},
-			"rateLimit": {
-				"cost": 2,
-				"remaining": 4997
-			}
-		},
+        "response": {
+            "search": {
+                "edges": [{
+                    "node": [{
+                        "state": "OPEN",
+                        "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+                        "title": "dummy PR",
+                        "number": 1,
+                        "merged": false,
+                        "mergeable": "MERGEABLE",
+                        "reviewDecision": null,
+                        "potentialMergeCommit": {
+                            "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+                        },
+                        "commits": {
+                            "nodes": [{
+                                "commit": {
+                                    "statusCheckRollup": null
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }
+        },
+        "argPr": "2",
+        "expected": [],
+        "description": "One pr found and argPR specified but not found: return empty array"
+    },
+    {
+        "response": {
+            "search": {
+                "edges": [{
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+                            "title": "dummy PR",
+                            "number": 1,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
+                            "title": "dummy PR 2",
+                            "number": 2,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
+                            "title": "dummy PR 3",
+                            "number": 3,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                ]
+            },
+            "rateLimit": {
+                "cost": 2,
+                "remaining": 4997
+            }
+        },
         "argPr": "1",
-		"expected": [],
-		"description": "Multiple prs found and argPR specified not found: return empty array"
-	},
+        "expected": [{
+            "state": "OPEN",
+            "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+            "title": "dummy PR",
+            "number": 1,
+            "merged": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": null,
+            "potentialMergeCommit": {
+                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+            },
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": null
+                    }
+                }]
+            }
+        }],
+        "description": "Multiple prs found and argPR specified found: filter out and only return one that matches argPr"
+    },
     {
-		"response": {
-			"search": {
-				"edges": [
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-								"title": "dummy PR",
-								"number": 1,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
-								"title": "dummy PR 2",
-								"number": 2,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					},
-					{
-						"node": [
-							{
-								"state": "OPEN",
-								"url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
-								"title": "dummy PR 3",
-								"number": 3,
-								"merged": false,
-								"mergeable": "MERGEABLE",
-								"reviewDecision": null,
-								"potentialMergeCommit": {
-									"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
-								},
-								"commits": {
-									"nodes": [
-										{
-											"commit": {
-												"statusCheckRollup": null
-											}
-										}
-									]
-								}
-							}
-						]
-					}
-				]
-			},
-			"rateLimit": {
-				"cost": 2,
-				"remaining": 4997
-			}
-		},
-		"expected": [
-			{
-				"state": "OPEN",
-				"url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
-				"title": "dummy PR",
-				"number": 1,
-				"merged": false,
-				"mergeable": "MERGEABLE",
-				"reviewDecision": null,
-				"potentialMergeCommit": {
-					"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
-				},
-				"commits": {
-					"nodes": [
-						{
-							"commit": {
-								"statusCheckRollup": null
-							}
-						}
-					]
-				}
-			},
-			{
-				"state": "OPEN",
-				"url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
-				"title": "dummy PR 2",
-				"number": 2,
-				"merged": false,
-				"mergeable": "MERGEABLE",
-				"reviewDecision": null,
-				"potentialMergeCommit": {
-					"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
-				},
-				"commits": {
-					"nodes": [
-						{
-							"commit": {
-								"statusCheckRollup": null
-							}
-						}
-					]
-				}
-			},
-			{
-				"state": "OPEN",
-				"url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
-				"title": "dummy PR 3",
-				"number": 3,
-				"merged": false,
-				"mergeable": "MERGEABLE",
-				"reviewDecision": null,
-				"potentialMergeCommit": {
-					"commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
-				},
-				"commits": {
-					"nodes": [
-						{
-							"commit": {
-								"statusCheckRollup": null
-							}
-						}
-					]
-				}
-			}
-		],
-		"description": "Multiple prs found and no argPR: return all PRs"
-	}
+        "response": {
+            "search": {
+                "edges": [{
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+                            "title": "dummy PR",
+                            "number": 5,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
+                            "title": "dummy PR 2",
+                            "number": 2,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
+                            "title": "dummy PR 3",
+                            "number": 3,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                ]
+            },
+            "rateLimit": {
+                "cost": 2,
+                "remaining": 4997
+            }
+        },
+        "argPr": "1",
+        "expected": [],
+        "description": "Multiple prs found and argPR specified not found: return empty array"
+    },
+    {
+        "response": {
+            "search": {
+                "edges": [{
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+                            "title": "dummy PR",
+                            "number": 1,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
+                            "title": "dummy PR 2",
+                            "number": 2,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "node": [{
+                            "state": "OPEN",
+                            "url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
+                            "title": "dummy PR 3",
+                            "number": 3,
+                            "merged": false,
+                            "mergeable": "MERGEABLE",
+                            "reviewDecision": null,
+                            "potentialMergeCommit": {
+                                "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
+                            },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": null
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                ]
+            },
+            "rateLimit": {
+                "cost": 2,
+                "remaining": 4997
+            }
+        },
+        "expected": [{
+                "state": "OPEN",
+                "url": "https://github.com/MeghalBisht/dummy-repo/pull/1",
+                "title": "dummy PR",
+                "number": 1,
+                "merged": false,
+                "mergeable": "MERGEABLE",
+                "reviewDecision": null,
+                "potentialMergeCommit": {
+                    "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/1f197b41bfd76a2fb5480a6af5a6bc6d06a7f6e7"
+                },
+                "commits": {
+                    "nodes": [{
+                        "commit": {
+                            "statusCheckRollup": null
+                        }
+                    }]
+                }
+            },
+            {
+                "state": "OPEN",
+                "url": "https://github.com/MeghalBisht/dummy-repo/pull/2",
+                "title": "dummy PR 2",
+                "number": 2,
+                "merged": false,
+                "mergeable": "MERGEABLE",
+                "reviewDecision": null,
+                "potentialMergeCommit": {
+                    "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/636e6f943e0dd719b49aeec53991a0e7384a684d"
+                },
+                "commits": {
+                    "nodes": [{
+                        "commit": {
+                            "statusCheckRollup": null
+                        }
+                    }]
+                }
+            },
+            {
+                "state": "OPEN",
+                "url": "https://github.com/MeghalBisht/dummy-repo/pull/3",
+                "title": "dummy PR 3",
+                "number": 3,
+                "merged": false,
+                "mergeable": "MERGEABLE",
+                "reviewDecision": null,
+                "potentialMergeCommit": {
+                    "commitUrl": "https://github.com/MeghalBisht/dummy-repo/commit/0ffc1461f1ad736fa27ee1c38856cff5611673e1"
+                },
+                "commits": {
+                    "nodes": [{
+                        "commit": {
+                            "statusCheckRollup": null
+                        }
+                    }]
+                }
+            }
+        ],
+        "description": "Multiple prs found and no argPR: return all PRs"
+    }
 ]

--- a/utils/buildQuery.js
+++ b/utils/buildQuery.js
@@ -15,6 +15,7 @@ const pullRequestQuery = (name, owner, pr, sha) => `
           author {
             login
           }
+           viewerCanMergeAsAdmin
           number
           merged
           mergeable

--- a/utils/evaluatePullRequest.js
+++ b/utils/evaluatePullRequest.js
@@ -18,6 +18,7 @@ module.exports = function evaluatePullRequest(response) {
 		merged,
 		state,
 		reviewDecision,
+		viewerCanMergeAsAdmin,
 	} = response;
 
 	if (state !== 'OPEN') {
@@ -59,7 +60,7 @@ module.exports = function evaluatePullRequest(response) {
 	if (reviewDecision === 'CHANGES_REQUESTED') {
 		return pullRequestStatus.REVIEW_DISAPPROVED;
 	} else if (reviewDecision === 'REVIEW_REQUIRED') {
-		return pullRequestStatus.REVIEW_REQUIRED;
+		return !viewerCanMergeAsAdmin ? pullRequestStatus.REVIEW_REQUIRED : pullRequestStatus.BYPASSABLE;
 	}
 
 	return pullRequestStatus.MERGEABLE;

--- a/utils/models/pullRequestStatus.js
+++ b/utils/models/pullRequestStatus.js
@@ -10,4 +10,5 @@ module.exports = {
 	REVIEW_REQUIRED: 'ℹ This PR requires a review - merging is blocked',
 	STATUS_FAILURE: '⚠ Some status checks are not successful',
 	STATUS_PENDING: 'ℹ Some status checks are pending',
+	BYPASSABLE: 'ℹ This PR requires a review before merging, but as an ADMIN with merge rights you can bypass that restriction',
 };


### PR DESCRIPTION
This PR fixes #23 .
I dug into the github API docs and found a direct solution to check if the viewer/person running "can-merge" can or not override the branch protections and merge the PR as an admin .
`viewerCanMergeAsAdmin` using this, Github API directly returns a boolean if the user can merge a Repo as Admin or not.